### PR TITLE
docs: surface the events-ringbuf-size-0 default in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Everything necessary to run [`rs-matter`](https://github.com/project-chip/rs-mat
 
 Since ESP-IDF does support the Rust Standard Library, UDP networking just works.
 
+## Event ring-buffer
+
+`esp-idf-matter` re-exports `rs-matter-stack`'s `events-ringbuf-size-*` features. **The default is `events-ringbuf-size-0`**, which disables event emission: `emit_event()` returns `Ok` and the device-side event counter still advances, but no bytes are stored and controllers never see any events. Devices that emit events &mdash; including any Generic Switch (0x000F), and any device required to send `BasicInformation::StartUp` on boot (Matter Core &sect;11.1.6) &mdash; must enable a non-zero size, e.g.:
+
+```toml
+esp-idf-matter = { ..., features = ["events-ringbuf-size-512"] }
+```
+
+See [`rs-matter-stack`](https://github.com/ivmarkov/rs-matter-stack)'s README for sizing guidance.
+
 ## Example
 
 (See also [All examples](#all-examples))


### PR DESCRIPTION
Hi again :)

Spent a few hours yesterday debugging a Matter Generic Switch firmware where button presses fired correctly device-side (FSM, cluster handler, `emit_for` all returning `Ok`, `max_seen_event_number` advancing on every press) but matter.js never logged a single `Received event ...`. Turned out to be the `events-ringbuf-size-0` default — every `emit_event()` silently no-ops in `EventWriter::write` and only the counter advances. The `# default, i.e. events will not be emitted` comment in `Cargo.toml` is technically accurate but easy to miss when readers go to the README first; the failure mode is also subtle (the device behaves as if events went out, but they never reach the wire).

This is just a small README note pointing users at the feature and suggesting a non-zero size for devices that emit any events. Today in rs-matter that includes any cluster handler calling `emit_for` (our use case: Switch events on a Generic Switch device type) plus the `AccessControlEntryChanged` event from ACL writes during commissioning. Wording is just a sketch — feel free to rewrite or shorten.

An alternative (if it makes sense to you) would be to change the default to a non-zero size like 256 or 512, so devices that emit any event work out of the box and only users explicitly disabling events would opt into 0.

A matching note is open at sysgrok/rs-matter-stack#37.